### PR TITLE
Add .gitattributes file treating .svelte files as .html

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,1 @@
+*.svelte linguist-language=HTML


### PR DESCRIPTION
This PR adds a `.gitattributes` file that gives HTML syntax highlighting for `.svelte` files.